### PR TITLE
update ubuntu and nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -10,7 +10,7 @@ RUN apt-get update
 RUN apt-get install -yqq \
     git curl python3-pip libyaml-dev zip unzip jq software-properties-common wget
 RUN pip3 install yamllint yq
-RUN curl -sL https://deb.nodesource.com/setup_17.x | bash - && apt-get install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -y nodejs
 RUN npm install -g ajv-cli
 
 COPY ./common /opt/basics/common


### PR DESCRIPTION
Ubuntu 21.10 "Impish Indri" больше не поддерживается. `apt-get update` и `apt-get install` не работают. Нет возможности обновиться или устанавливать программы – https://askubuntu.com/questions/1420190/impish-release-no-longer-has-a-release-file

Дальше по цепочке _Node.js 17.x is no longer actively supported!_